### PR TITLE
 Bump to 1.1, add privacy policy, and fix 著 phrase conversion

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,46 @@
+# Privacy Policy
+
+Effective date: 2026-06-30
+
+Simplified/Traditional Chinese Converter is a Chrome extension that converts web
+page text between Simplified Chinese, Traditional Chinese, Pinyin, and Cantonese
+inside the user's browser.
+
+## Data Collection
+
+This extension does not collect, transmit, sell, rent, or share personal or
+sensitive user data.
+
+## Local Processing
+
+The extension reads text from web pages only to perform the selected conversion
+locally in the browser. Page content is not sent to the developer or to any
+third-party service.
+
+## Stored Settings
+
+The extension uses the Chrome `storage` permission to save user preferences such
+as the selected conversion mode, dialect option, whitelist patterns, and
+blacklist patterns. These settings are stored with Chrome extension storage and
+may sync across the user's Chrome browsers if Chrome sync is enabled.
+
+## Third-Party Services
+
+The extension does not use analytics, advertising, tracking pixels, remote code,
+or third-party data processing services.
+
+## Data Retention and Deletion
+
+The extension keeps only the settings stored by Chrome extension storage. Users
+can change these settings in the extension popup or remove them by uninstalling
+the extension and clearing Chrome extension data.
+
+## Permissions
+
+The extension requests the `storage` permission so it can remember user settings.
+It also runs content scripts on web pages so it can convert visible text in the
+browser.
+
+## Contact
+
+For privacy questions, contact: dr.zhihua.lai@gmail.com

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 [![License: MIT](https://img.shields.io/github/license/DoctorLai/Simplified-and-Traditional-Chinese)](LICENSE)
 [![Code style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4?logo=prettier&logoColor=white)](https://prettier.io/)
 [![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![Privacy Policy](https://img.shields.io/badge/privacy-policy-0f766e)](PRIVACY.md)
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/olpihmabpjpllgmahlgiakkgaccigpfo?label=chrome%20web%20store&logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/olpihmabpjpllgmahlgiakkgaccigpfo)
 [![Users](https://img.shields.io/chrome-web-store/users/olpihmabpjpllgmahlgiakkgaccigpfo?label=users)](https://chromewebstore.google.com/detail/olpihmabpjpllgmahlgiakkgaccigpfo)
@@ -129,6 +130,11 @@ tests/                  # Jest unit tests
 
 Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) and make
 sure `npm run check` passes before opening a pull request.
+
+## Privacy
+
+This extension runs locally in your browser and does not collect, transmit, sell,
+or share personal data. See the [Privacy Policy](PRIVACY.md) for details.
 
 ## Support
 

--- a/gb2312-big5/js/convert.js
+++ b/gb2312-big5/js/convert.js
@@ -51,11 +51,42 @@ function Traditionalized(cc) {
   return str;
 }
 
+const TRADITIONAL_TO_SIMPLIFIED_PHRASES = [
+  ['著作權', '著作权'],
+  ['顯著', '显著'],
+  ['著名', '著名'],
+  ['著作', '著作'],
+  ['著述', '著述'],
+  ['著者', '著者'],
+  ['著稱', '著称'],
+  ['著書', '著书'],
+  ['著錄', '著录'],
+  ['卓著', '卓著'],
+  ['昭著', '昭著'],
+  ['土著', '土著'],
+  ['原著', '原著'],
+  ['名著', '名著'],
+  ['巨著', '巨著'],
+  ['專著', '专著'],
+  ['編著', '编著'],
+  ['譯著', '译著'],
+  ['合著', '合著'],
+  ['遺著', '遗著']
+];
+
 function Simplized(cc) {
   let str = '';
   const ss = JTPYStr();
   const tt = FTPYStr();
   for (let i = 0; i < cc.length; i += 1) {
+    const phrase = TRADITIONAL_TO_SIMPLIFIED_PHRASES.find(([traditional]) =>
+      cc.startsWith(traditional, i)
+    );
+    if (phrase) {
+      str += phrase[1];
+      i += phrase[0].length - 1;
+      continue;
+    }
     if (testChinese(cc, i) && tt.indexOf(cc.charAt(i)) != -1) {
       str += ss.charAt(tt.indexOf(cc.charAt(i)));
     } else {

--- a/gb2312-big5/manifest.json
+++ b/gb2312-big5/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_appName__",
   "default_locale": "en",
   "short_name": "ZH Convert",
-  "version": "1.0",
+  "version": "1.1",
   "action": {
     "default_icon": "icon.png",
     "default_title": "__MSG_appName__",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "simplified-and-traditional-chinese",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "simplified-and-traditional-chinese",
-      "version": "1.0.0",
+      "version": "1.1.0",
       "license": "MIT",
       "devDependencies": {
         "@eslint/js": "^9.13.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-and-traditional-chinese",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Chrome extension that automatically converts web pages between Simplified Chinese, Traditional Chinese, Pinyin and Cantonese.",
   "private": true,
   "type": "commonjs",

--- a/tests/convert.test.js
+++ b/tests/convert.test.js
@@ -31,6 +31,17 @@ describe('Traditionalized / Simplized', () => {
     expect(Simplized('簡體中文')).toBe('简体中文');
   });
 
+  it('keeps 著 in simplified phrases that use 著', () => {
+    expect(Simplized('最著名的著作')).toBe('最著名的著作');
+    expect(Simplized('著稱的著書與著作權')).toBe('著称的著书与著作权');
+    expect(Simplized('顯著成果與世界名著')).toBe('显著成果与世界名著');
+    expect(Simplized('專著、編著、譯著和合著')).toBe('专著、编著、译著和合著');
+  });
+
+  it('still converts standalone 著 to 着', () => {
+    expect(Simplized('看著')).toBe('看着');
+  });
+
   it('leaves non-Chinese text untouched', () => {
     expect(Traditionalized('Hello 123!')).toBe('Hello 123!');
     expect(Simplized('Hello 123!')).toBe('Hello 123!');
@@ -64,6 +75,10 @@ describe('translateText', () => {
 
   it('converts to simplified (encoding 1)', () => {
     expect(translateText('簡體', 1, 0)).toBe('简体');
+  });
+
+  it('keeps 著名 when converting to simplified', () => {
+    expect(translateText('最著名的人', 1, 0)).toBe('最著名的人');
   });
 
   it('converts to traditional (encoding 2)', () => {

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -26,6 +26,12 @@ describe('translateBody', () => {
     expect(document.body.textContent).toBe('简体中文');
   });
 
+  it('keeps 著名 when simplifying page text', () => {
+    document.body.innerHTML = '<div>最著名的人</div>';
+    translateBody(document.body, 1, 0);
+    expect(document.body.textContent).toBe('最著名的人');
+  });
+
   it('translates the alt attribute of elements', () => {
     document.body.innerHTML = '<img alt="简体">';
     translateBody(document.body, 2, 0);


### PR DESCRIPTION

This PR prepares the Chrome Web Store resubmission by bumping the extension to
version 1.1 and adding a direct privacy policy document.

It also fixes a Simplified Chinese conversion regression where phrase-level uses
of `著` could be incorrectly converted to `着`, such as `著名` becoming `着名`.
The converter now handles common `著` compounds before falling back to the
existing character-by-character conversion table.

## Changes

- Bump extension metadata from `1.0` to `1.1` in `gb2312-big5/manifest.json`.
- Bump npm package metadata from `1.0.0` to `1.1.0` in `package.json` and
  `package-lock.json`.
- Add `PRIVACY.md` with a direct privacy policy covering local processing,
  Chrome storage usage, no analytics/tracking, and no data sharing.
- Link the privacy policy from `README.md`.
- Add phrase-level Traditional-to-Simplified overrides for common `著` terms,
  including `著名`, `著作`, `著作權`, `顯著`, `名著`, `專著`, `編著`, `譯著`, and
  related compounds.
- Add regression coverage for direct text conversion and DOM/page text
  conversion.

## Validation

```bash
npx jest tests/convert.test.js tests/dom.test.js
npm run check
npm run build
```

All checks pass. The build creates:

```text
dist/simplified-and-traditional-chinese-v1.1.zip
```

## Notes

- The blacklist/whitelist behavior is unchanged: blacklist matches still take
  priority over whitelist matches.
- The privacy policy is intended to be linked directly from the Chrome Web Store
  privacy policy field after this branch is pushed or merged.
