### PR TITLE
Release 1.2 — docs, badges, i18n, tests & tooling

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,12 +1,3 @@
-# These are supported funding model platforms
-
-github: [doctorlai] # Replace with up to 4 GitHub Sponsors-enabled usernames e.g., [user1, user2]
+github: [doctorlai]
 patreon: doctorlai
-open_collective: # Replace with a single Open Collective username
-ko_fi: # Replace with a single Ko-fi username
-tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
-community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
-liberapay: # Replace with a single Liberapay username
-issuehunt: # Replace with a single IssueHunt username
-otechie: # Replace with a single Otechie username
-custom: ['https://www.buymeacoffee.com/y0BtG5R', 'https://paypal.me/doctorlai/3'] # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+custom: ['https://www.buymeacoffee.com/y0BtG5R', 'https://paypal.me/doctorlai/3']

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+<!--
+Thanks for contributing! Please fill in the sections below and delete any that
+do not apply. See CONTRIBUTING.md for details.
+-->
+
+## Summary
+
+<!-- What does this PR do and why? -->
+
+## Related issues
+
+<!-- e.g. "Closes #123" or "Refs #123". Delete if not applicable. -->
+
+## Type of change
+
+- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
+- [ ] ✨ New feature (non-breaking change that adds functionality)
+- [ ] 💥 Breaking change (fix or feature that changes existing behaviour)
+- [ ] 📝 Documentation update
+- [ ] 🧹 Refactor / chore (no functional change)
+
+## How has this been tested?
+
+<!-- Describe the tests you ran and/or the manual steps to verify the change. -->
+
+- [ ] Loaded the unpacked extension from `gb2312-big5/` and verified in Chrome.
+- [ ] Added or updated unit tests where practical.
+
+## Checklist
+
+- [ ] `npm run check` passes locally (lint + format + coverage).
+- [ ] `npm run build` produces a valid package.
+- [ ] New behaviour is covered by tests where practical.
+- [ ] Documentation (README / CONTRIBUTING) updated if needed.
+- [ ] Commit messages are clear and descriptive.
+- [ ] I have read the [CONTRIBUTING](/CONTRIBUTING.md) guide.

--- a/.github/badges/javascript.json
+++ b/.github/badges/javascript.json
@@ -1,0 +1,8 @@
+{
+  "schemaVersion": 1,
+  "label": "JavaScript",
+  "message": "88.3%",
+  "color": "F7DF1E",
+  "namedLogo": "javascript",
+  "logoColor": "black"
+}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+# Dependabot keeps npm dependencies and GitHub Actions up to date.
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  # JavaScript / npm dependencies.
+  - package-ecosystem: npm
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - javascript
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      dev-dependencies:
+        dependency-type: development
+
+  # GitHub Actions used by the CI workflow.
+  - package-ecosystem: github-actions
+    directory: '/'
+    schedule:
+      interval: weekly
+      day: monday
+    labels:
+      - dependencies
+      - github-actions
+    commit-message:
+      prefix: chore
+      include: scope

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master, main, '1.0']
+    branches: [master, main, '[0-9]+.[0-9]+']
   pull_request:
 
 permissions:

--- a/.github/workflows/language-badge.yml
+++ b/.github/workflows/language-badge.yml
@@ -1,0 +1,67 @@
+name: Language badge
+
+# Recomputes the JavaScript share of the repository from GitHub's own Linguist
+# stats (which already honour .gitattributes vendoring/generation rules) and
+# stores it as a shields.io "endpoint" badge under .github/badges/.
+
+on:
+  push:
+    branches: [master, main]
+  workflow_dispatch:
+  schedule:
+    # Weekly refresh in case language stats drift without a push.
+    - cron: '0 3 * * 1'
+
+permissions:
+  contents: write
+
+concurrency:
+  group: language-badge-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  javascript:
+    name: Update JavaScript badge
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate badge data
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { data } = await github.rest.repos.listLanguages({
+              owner: context.repo.owner,
+              repo: context.repo.repo
+            });
+            const total = Object.values(data).reduce((sum, n) => sum + n, 0);
+            const js = data.JavaScript || 0;
+            const pct = total ? (js / total) * 100 : 0;
+            const badge = {
+              schemaVersion: 1,
+              label: 'JavaScript',
+              message: `${pct.toFixed(1)}%`,
+              color: 'F7DF1E',
+              namedLogo: 'javascript',
+              logoColor: 'black'
+            };
+            fs.mkdirSync('.github/badges', { recursive: true });
+            fs.writeFileSync(
+              '.github/badges/javascript.json',
+              JSON.stringify(badge, null, 2) + '\n'
+            );
+            core.info(`JavaScript: ${badge.message}`);
+
+      - name: Commit updated badge
+        run: |
+          if [[ -n "$(git status --porcelain .github/badges/javascript.json)" ]]; then
+            git config user.name "github-actions[bot]"
+            git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+            git add .github/badges/javascript.json
+            git commit -m "chore: update JavaScript language badge [skip ci]"
+            git push
+          else
+            echo "JavaScript badge already up to date."
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.2.0] - 2026-07-08
+
+### Added
+
+- Repository documentation and automation: `SECURITY.md`, `CODE_OF_CONDUCT.md`,
+  `CHANGELOG.md`, a pull request template, and a Dependabot configuration for npm
+  and GitHub Actions updates.
+- Localized Chrome Web Store metadata for **25** languages — added Bengali,
+  Marathi, Telugu, Tamil, and Filipino.
+- A self-updating, dynamic **JavaScript percentage** badge plus additional
+  repository badges (forks, watchers, open PRs, commit activity, repo size, top
+  language, Ask DeepWiki).
+- New npm scripts: `fix` (lint + format auto-fix), `test:watch`, and `clean`.
+- Expanded the Jest suite with Pinyin edge cases, dialect (Mandarin → Cantonese)
+  conversion, DOM attribute handling, and the content-script bootstrap, reaching
+  100% statement/function/line coverage of `convert.js`.
+
+### Changed
+
+- `npm run check` now also runs the build, and coverage thresholds were raised.
+- Continuous integration runs on release branches and refreshes the language
+  badge automatically.
+
+## [1.1.0] - 2025
+
+### Added
+
+- Privacy Policy (`PRIVACY.md`).
+
+### Fixed
+
+- Keep 著 in simplified phrases such as 著名, 著作, and 顯著 while still converting
+  a standalone 著 to 着.
+
+## [1.0.0]
+
+### Added
+
+- Initial public release of the Manifest V3 Chrome extension:
+  - Simplified ⇄ Traditional Chinese conversion.
+  - Tone-marked Hanyu Pinyin annotation.
+  - Experimental Cantonese ⇄ Mandarin dialect conversion.
+  - Domain whitelist and blacklist (substring or regular expression).
+  - Settings synced via `chrome.storage.sync`.
+
+[unreleased]: https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/compare/v1.2.0...HEAD
+[1.2.0]: https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/compare/v1.1...v1.2.0
+[1.1.0]: https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/releases/tag/v1.1
+[1.0.0]: https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/releases/tag/v1.0

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[dr.zhihua.lai@gmail.com](mailto:dr.zhihua.lai@gmail.com). All complaints will be
+reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,6 +4,11 @@ Thanks for your interest in improving the **Simplified / Traditional Chinese Con
 Chrome extension! Contributions of all kinds are welcome — bug reports, feature
 requests, documentation fixes and pull requests.
 
+This project follows the
+[Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you
+are expected to uphold this code. Notable changes are tracked in the
+[Changelog](CHANGELOG.md).
+
 ## Project layout
 
 ```
@@ -42,10 +47,13 @@ npm install
 | `npm run lint:fix`     | Lint and auto-fix where possible.                                 |
 | `npm run format`       | Format the codebase with Prettier.                                |
 | `npm run format:check` | Verify formatting without writing changes.                        |
+| `npm run fix`          | Auto-fix lint issues and reformat in one step.                    |
 | `npm test`             | Run the Jest unit tests.                                          |
+| `npm run test:watch`   | Run the Jest unit tests in watch mode.                            |
 | `npm run coverage`     | Run the tests and enforce the coverage threshold.                 |
-| `npm run check`        | Run lint + format check + coverage (what CI runs).                |
+| `npm run check`        | Run lint + format check + coverage + build (what CI runs).        |
 | `npm run build`        | Package the extension into `dist/*.zip` for the Chrome Web Store. |
+| `npm run clean`        | Remove the `dist/` and `coverage/` build artifacts.               |
 
 Please make sure `npm run check` passes before opening a pull request.
 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,35 @@
 
 <!-- Badges -->
 
+<!-- Build & quality -->
+
 [![CI](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/actions/workflows/ci.yml/badge.svg)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/actions/workflows/ci.yml)
-[![Node.js](https://img.shields.io/badge/node-%3E%3D18-339933?logo=node.js&logoColor=white)](https://nodejs.org/)
-[![Manifest V3](https://img.shields.io/badge/manifest-v3-4285F4?logo=googlechrome&logoColor=white)](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3)
-[![License: MIT](https://img.shields.io/github/license/DoctorLai/Simplified-and-Traditional-Chinese)](LICENSE)
-[![Last commit](https://img.shields.io/github/last-commit/doctorlai/Simplified-and-Traditional-Chinese?logo=github)](https://github.com/doctorlai/Simplified-and-Traditional-Chinese/commits)
+[![Node.js](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/DoctorLai/Simplified-and-Traditional-Chinese/master/package.json&query=$.engines.node&label=node&logo=node.js&logoColor=white&color=339933)](https://nodejs.org/)
+[![Manifest](https://img.shields.io/badge/dynamic/json?url=https://raw.githubusercontent.com/DoctorLai/Simplified-and-Traditional-Chinese/master/gb2312-big5/manifest.json&query=$.manifest_version&label=manifest&prefix=v&logo=googlechrome&logoColor=white&color=4285F4)](https://developer.chrome.com/docs/extensions/develop/migrate/what-is-mv3)
 [![Code style: Prettier](https://img.shields.io/badge/code_style-prettier-ff69b4?logo=prettier&logoColor=white)](https://prettier.io/)
-[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
-[![Issues](https://img.shields.io/github/issues/doctorlai/Simplified-and-Traditional-Chinese?logo=github)](https://github.com/doctorlai/Simplified-and-Traditional-Chinese/issues)
+[![License: MIT](https://img.shields.io/github/license/DoctorLai/Simplified-and-Traditional-Chinese)](LICENSE)
 [![Privacy Policy](https://img.shields.io/badge/privacy-policy-0f766e)](PRIVACY.md)
+[![PRs welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/DoctorLai/Simplified-and-Traditional-Chinese)
+
+<!-- Repository stats -->
+
+[![GitHub stars](https://img.shields.io/github/stars/DoctorLai/Simplified-and-Traditional-Chinese?logo=github)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/stargazers)
+[![GitHub forks](https://img.shields.io/github/forks/DoctorLai/Simplified-and-Traditional-Chinese?logo=github)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/network/members)
+[![GitHub watchers](https://img.shields.io/github/watchers/DoctorLai/Simplified-and-Traditional-Chinese?logo=github)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/watchers)
+[![GitHub open issues](https://img.shields.io/github/issues/DoctorLai/Simplified-and-Traditional-Chinese?logo=github)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/issues)
+[![GitHub open PRs](https://img.shields.io/github/issues-pr/DoctorLai/Simplified-and-Traditional-Chinese?logo=github)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/pulls)
+[![Last commit](https://img.shields.io/github/last-commit/DoctorLai/Simplified-and-Traditional-Chinese?logo=github)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/commits)
+[![Commit activity](https://img.shields.io/github/commit-activity/m/DoctorLai/Simplified-and-Traditional-Chinese?logo=github)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/commits)
+[![Repo size](https://img.shields.io/github/repo-size/DoctorLai/Simplified-and-Traditional-Chinese?logo=github)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese)
+[![Top language](https://img.shields.io/github/languages/top/DoctorLai/Simplified-and-Traditional-Chinese?logo=javascript&logoColor=black)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese)
+[![JavaScript](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/DoctorLai/Simplified-and-Traditional-Chinese/master/.github/badges/javascript.json)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/search?l=javascript)
+
+<!-- Chrome Web Store -->
 
 [![Chrome Web Store](https://img.shields.io/chrome-web-store/v/olpihmabpjpllgmahlgiakkgaccigpfo?label=chrome%20web%20store&logo=googlechrome&logoColor=white)](https://chromewebstore.google.com/detail/olpihmabpjpllgmahlgiakkgaccigpfo)
 [![Users](https://img.shields.io/chrome-web-store/users/olpihmabpjpllgmahlgiakkgaccigpfo?label=users)](https://chromewebstore.google.com/detail/olpihmabpjpllgmahlgiakkgaccigpfo)
 [![Rating](https://img.shields.io/chrome-web-store/rating/olpihmabpjpllgmahlgiakkgaccigpfo?label=rating)](https://chromewebstore.google.com/detail/olpihmabpjpllgmahlgiakkgaccigpfo)
-[![GitHub stars](https://img.shields.io/github/stars/DoctorLai/Simplified-and-Traditional-Chinese?style=flat&logo=github)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/stargazers)
-[![Last commit](https://img.shields.io/github/last-commit/DoctorLai/Simplified-and-Traditional-Chinese)](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/commits)
 
 <img width="1164" height="882" alt="image" src="https://github.com/user-attachments/assets/b4f75021-1b72-44e6-a8a3-4a438e4b9f8c" />
 <img width="1133" height="394" alt="image" src="https://github.com/user-attachments/assets/1c65b389-88a8-4694-b44b-97ba9203dc33" />
@@ -40,10 +54,11 @@
   requests only the `storage` permission.
 - ⚡ **Manifest V3** — built on the modern, service‑worker based extension
   platform.
-- 🌍 **Localized metadata** — Chrome Web Store metadata now covers 20 major
-  language/region targets, including English, Chinese, Spanish, Arabic,
-  Portuguese, Indonesian, French, Japanese, Russian, German, Korean, Hindi,
-  Turkish, Italian, Dutch, Polish, Vietnamese, Persian and Thai.
+- 🌍 **Localized metadata** — Chrome Web Store metadata now covers 25 major
+  language targets, including English, Chinese, Spanish, Arabic, Portuguese,
+  Indonesian, French, Japanese, Russian, German, Korean, Hindi, Turkish,
+  Italian, Dutch, Polish, Vietnamese, Persian, Thai, Bengali, Marathi, Telugu,
+  Tamil and Filipino.
 
 ## Install
 
@@ -97,10 +112,13 @@ npm install
 | `npm run lint:fix`     | Lint and auto‑fix where possible.                                 |
 | `npm run format`       | Format the codebase with Prettier.                                |
 | `npm run format:check` | Verify formatting without writing changes.                        |
+| `npm run fix`          | Auto‑fix lint issues and reformat in one step.                    |
 | `npm test`             | Run the Jest unit tests.                                          |
+| `npm run test:watch`   | Run the Jest unit tests in watch mode.                            |
 | `npm run coverage`     | Run the tests and enforce the coverage threshold.                 |
-| `npm run check`        | Run lint + format check + coverage (the CI gate).                 |
+| `npm run check`        | Run lint + format check + coverage + build (the CI gate).         |
 | `npm run build`        | Package the extension into `dist/*.zip` for the Chrome Web Store. |
+| `npm run clean`        | Remove the `dist/` and `coverage/` build artifacts.               |
 
 ### Build a publishable package
 
@@ -111,6 +129,19 @@ npm run build
 
 The generated `.zip` has `manifest.json` at its root and can be uploaded
 directly to the [Chrome Web Store Developer Dashboard](https://chrome.google.com/webstore/devconsole).
+
+## Testing
+
+Unit tests run on [Jest](https://jestjs.io/) and cover the pure conversion
+helpers, DOM traversal, the localized metadata, and the content-script bootstrap:
+
+```bash
+npm test          # run the suite
+npm run coverage  # run with coverage and enforce the thresholds
+```
+
+Coverage is collected from `gb2312-big5/js/convert.js` and gated in CI. Please
+add or update tests when you change conversion behaviour.
 
 ## Project structure
 
@@ -124,30 +155,37 @@ gb2312-big5/            # The unpacked extension (this is what gets zipped & pub
     main.js             # Popup logic
     dialect.js          # Cantonese <-> Mandarin tables
     pinyin.js           # Pinyin lookup table (generated data)
-  _locales/             # i18n messages
+  _locales/             # i18n messages (25 locales)
 scripts/build.js        # Packages the extension into dist/*.zip
-tests/                  # Jest unit tests
+tests/                  # Jest unit tests (convert, DOM, i18n, content-script)
 ```
 
 ## Contributing
 
-Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md) and make
-sure `npm run check` passes before opening a pull request.
+Contributions are welcome! Please read [CONTRIBUTING.md](CONTRIBUTING.md), follow
+our [Code of Conduct](CODE_OF_CONDUCT.md), and make sure `npm run check` passes
+before opening a pull request. Notable changes are recorded in the
+[Changelog](CHANGELOG.md).
 
 ## Privacy
 
 This extension runs locally in your browser and does not collect, transmit, sell,
 or share personal data. See the [Privacy Policy](PRIVACY.md) for details.
 
+## Security
+
+Found a vulnerability? Please report it privately — see our
+[Security Policy](SECURITY.md) for how to disclose issues responsibly.
+
 ## Support
 
 Enjoy what I am doing? Support me via:
 
-- [Buy me a coffee please ☕](https://helloacm.com/out/buymecoffee)
+- [Buy me a coffee please ☕](https://buymeacoffee.com/y0btg5r)
 - [Become a Github Sponsor 💰](https://github.com/sponsors/DoctorLai)
 - [Become a Patreon 💰](https://www.patreon.com/doctorlai)
-- **[Crypto Payment Accepted ₿](https://justyy.com/out/cryptopayment)**
-- [Paypal 🅿️](https://justyy.com/out/paypal)
+- **[Crypto Payment Accepted ₿](https://buymeacoffee.com/y0btg5r/crypto-payment-accepted)**
+- [Paypal 🅿️](https://paypal.me/doctorlai/5)
 
 More free online tools: <https://helloacm.com/tools/>
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,49 @@
+# Security Policy
+
+## Supported Versions
+
+Security fixes are applied to the latest released version of the extension. We
+recommend always running the most recent build from the
+[Chrome Web Store](https://chromewebstore.google.com/detail/olpihmabpjpllgmahlgiakkgaccigpfo).
+
+| Version | Supported          |
+| ------- | ------------------ |
+| 1.2.x   | :white_check_mark: |
+| < 1.2   | :x:                |
+
+## Reporting a Vulnerability
+
+Please **do not** open a public GitHub issue for security-sensitive reports.
+
+Instead, report vulnerabilities privately using one of the following channels:
+
+- **GitHub Security Advisories** — use the
+  [private vulnerability reporting](https://github.com/DoctorLai/Simplified-and-Traditional-Chinese/security/advisories/new)
+  form (preferred).
+- **Email** — send details to
+  [dr.zhihua.lai@gmail.com](mailto:dr.zhihua.lai@gmail.com), or use the contact
+  form on [justyy.com](https://justyy.com).
+
+When reporting, please include:
+
+- A clear description of the issue and its potential impact.
+- Step-by-step instructions to reproduce it.
+- The extension version, Chrome version, and operating system.
+- Any relevant logs, screenshots, or proof-of-concept code.
+
+## Response Process
+
+- We aim to acknowledge new reports within **5 business days**.
+- We will investigate, keep you informed of progress, and coordinate a fix and
+  disclosure timeline with you.
+- Once a fix is released, we are happy to credit reporters who wish to be
+  acknowledged.
+
+## Scope
+
+This extension runs entirely in the browser, requests only the `storage`
+permission, and does not transmit user data. Reports about data handling,
+content-script injection, permission scope, or supply-chain concerns
+(dependencies, build tooling) are all in scope.
+
+Thank you for helping keep users safe.

--- a/gb2312-big5/_locales/bn/messages.json
+++ b/gb2312-big5/_locales/bn/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "সরলীকৃত/ঐতিহ্যবাহী চীনা রূপান্তরকারী",
+    "description": "Extension name"
+  },
+  "appDesc": {
+    "message": "সরলীকৃত চীনা, ঐতিহ্যবাহী চীনা, পিনয়িন ও ক্যান্টনিজের মধ্যে ওয়েব পৃষ্ঠা রূপান্তর করুন।",
+    "description": "Extension description"
+  }
+}

--- a/gb2312-big5/_locales/fil/messages.json
+++ b/gb2312-big5/_locales/fil/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "Converter ng Pinasimple/Tradisyonal na Intsik",
+    "description": "Extension name"
+  },
+  "appDesc": {
+    "message": "I-convert ang mga web page sa pagitan ng Pinasimpleng Intsik, Tradisyonal na Intsik, Pinyin at Cantonese.",
+    "description": "Extension description"
+  }
+}

--- a/gb2312-big5/_locales/mr/messages.json
+++ b/gb2312-big5/_locales/mr/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "सरलीकृत/पारंपरिक चिनी रूपांतरक",
+    "description": "Extension name"
+  },
+  "appDesc": {
+    "message": "सरलीकृत चिनी, पारंपरिक चिनी, पिनयिन आणि कँटोनीज दरम्यान वेब पृष्ठे रूपांतरित करा.",
+    "description": "Extension description"
+  }
+}

--- a/gb2312-big5/_locales/ta/messages.json
+++ b/gb2312-big5/_locales/ta/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "எளிமையாக்கப்பட்ட/பாரம்பரிய சீன மாற்றி",
+    "description": "Extension name"
+  },
+  "appDesc": {
+    "message": "எளிமையான சீனம், பாரம்பரிய சீனம், பின்யின் மற்றும் கான்டனீஸ் இடையே இணையப் பக்கங்களை மாற்றவும்.",
+    "description": "Extension description"
+  }
+}

--- a/gb2312-big5/_locales/te/messages.json
+++ b/gb2312-big5/_locales/te/messages.json
@@ -1,0 +1,10 @@
+{
+  "appName": {
+    "message": "సరళీకృత/సాంప్రదాయ చైనీస్ కన్వర్టర్",
+    "description": "Extension name"
+  },
+  "appDesc": {
+    "message": "సరళీకృత చైనీస్, సాంప్రదాయ చైనీస్, పిన్‌యిన్ మరియు కాంటనీస్ మధ్య వెబ్ పేజీలను మార్చండి.",
+    "description": "Extension description"
+  }
+}

--- a/gb2312-big5/main.html
+++ b/gb2312-big5/main.html
@@ -58,7 +58,7 @@ justyy.com
           <BR/>          
           <a href="https://justyy.com/tools/chinese-converter/?ref=chrome_extension" target=_blank><img src='images/chinese.jpg' /><BR/><B><font color=blue>在线转换工具</font></B></a><BR/>
           <BR/>
-          <a href="https://helloacm.com/out/buymecoffee" target="_blank"><img src="images/lato-blue.png" alt="Buy Me A Coffee" style="height: 40px !important" ></a>
+          <a href="https://buymeacoffee.com/y0btg5r" target="_blank"><img src="images/lato-blue.png" alt="Buy Me A Coffee" style="height: 40px !important" ></a>
           <BR/>
           支持我的工作，<a href="https://chrome.google.com/webstore/detail/olpihmabpjpllgmahlgiakkgaccigpfo" target=_blank><b><font color=blue>给我评个分，给个好评呗</font></b>，</a>感谢。
       </div>
@@ -71,8 +71,8 @@ justyy.com
           <textarea readonly class='form-control' rows=9 id='about'>
           </textarea>
           <BR/>
-          <a target=_blank href='https://www.paypal.me/doctorlai/3'><img src='images/paypal.png' class='banner'></a> &nbsp;
-          <a target=_blank href='https://justyy.com/out/bitcoin'><img src='images/bitcoin.jpg' class='banner'></a>
+          <a target=_blank href='https://paypal.me/doctorlai/5'><img src='images/paypal.png' class='banner'></a> &nbsp;
+          <a target=_blank href='https://buymeacoffee.com/y0btg5r/crypto-payment-accepted'><img src='images/bitcoin.jpg' class='banner'></a>
           &nbsp;
           <a target=_blank href='https://justyy.com/out/vultr2'><img title='Free $10 VPS' src='images/vultr.jpg' class='banner'></a>
           &nbsp;

--- a/gb2312-big5/manifest.json
+++ b/gb2312-big5/manifest.json
@@ -3,7 +3,7 @@
   "name": "__MSG_appName__",
   "default_locale": "en",
   "short_name": "ZH Convert",
-  "version": "1.1",
+  "version": "1.2",
   "action": {
     "default_icon": "icon.png",
     "default_title": "__MSG_appName__",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "simplified-and-traditional-chinese",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Chrome extension that automatically converts web pages between Simplified Chinese, Traditional Chinese, Pinyin and Cantonese.",
   "private": true,
   "type": "commonjs",
@@ -9,9 +9,12 @@
     "lint:fix": "eslint . --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "fix": "npm run lint:fix && npm run format",
     "test": "jest",
+    "test:watch": "jest --watch",
     "coverage": "jest --coverage",
-    "check": "npm run lint && npm run format:check && npm run coverage",
+    "check": "npm run lint && npm run format:check && npm run coverage && npm run build",
+    "clean": "node scripts/clean.js",
     "build": "node scripts/build.js",
     "zip": "node scripts/build.js"
   },
@@ -60,10 +63,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 70,
-        "branches": 60,
-        "functions": 70,
-        "lines": 70
+        "statements": 95,
+        "branches": 90,
+        "functions": 95,
+        "lines": 95
       }
     }
   }

--- a/scripts/clean.js
+++ b/scripts/clean.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+/**
+ * Clean script: removes build and coverage artifacts (`dist/` and `coverage/`).
+ *
+ * Usage: `npm run clean`
+ */
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.resolve(__dirname, '..');
+const TARGETS = ['dist', 'coverage'];
+
+for (const target of TARGETS) {
+  const dir = path.join(ROOT, target);
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+    console.log(`Removed ${target}/`);
+  } else {
+    console.log(`Skipped ${target}/ (not present)`);
+  }
+}

--- a/tests/content-script.test.js
+++ b/tests/content-script.test.js
@@ -1,0 +1,75 @@
+/**
+ * @jest-environment jsdom
+ */
+
+// Exercises the content-script bootstrap in convert.js, which only runs when a
+// `chrome.storage.sync` API is present. The module is loaded in isolation with a
+// mocked chrome API so the auto-run logic executes against a real jsdom DOM.
+
+const flushMicrotasks = async () => {
+  for (let i = 0; i < 5; i += 1) {
+    await Promise.resolve();
+  }
+};
+
+function mockChrome(store) {
+  return {
+    storage: {
+      sync: {
+        get: (key) => Promise.resolve({ [key]: store[key] })
+      }
+    }
+  };
+}
+
+describe('content-script bootstrap (runContentScript)', () => {
+  const originalChrome = global.chrome;
+
+  afterEach(() => {
+    if (originalChrome === undefined) {
+      delete global.chrome;
+    } else {
+      global.chrome = originalChrome;
+    }
+    jest.useRealTimers();
+    jest.resetModules();
+  });
+
+  it('translates the page body using the synced settings', async () => {
+    jest.useFakeTimers();
+    document.body.innerHTML = '<p>简体中文</p>';
+    global.chrome = mockChrome({ setting: 2, dialect: 0, wlist: '', blist: '' });
+
+    jest.isolateModules(() => {
+      require('../gb2312-big5/js/convert.js');
+    });
+
+    await flushMicrotasks();
+    expect(document.body.textContent).toBe('簡體中文');
+
+    // The bootstrap re-applies the conversion a few times via setTimeout.
+    jest.advanceTimersByTime(5000);
+    await flushMicrotasks();
+    expect(document.body.textContent).toBe('簡體中文');
+  });
+
+  it('skips translation when the page is blacklisted', async () => {
+    jest.useFakeTimers();
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(() => {});
+    document.body.innerHTML = '<p>简体中文</p>';
+    // Default jsdom URL is http://localhost/, so blacklist "localhost".
+    global.chrome = mockChrome({ setting: 2, dialect: 0, wlist: '', blist: 'localhost' });
+
+    jest.isolateModules(() => {
+      require('../gb2312-big5/js/convert.js');
+    });
+
+    await flushMicrotasks();
+    jest.advanceTimersByTime(5000);
+    await flushMicrotasks();
+
+    expect(document.body.textContent).toBe('简体中文');
+    expect(logSpy).toHaveBeenCalledWith(expect.stringContaining('skipped by whitelist/blacklist'));
+    logSpy.mockRestore();
+  });
+});

--- a/tests/convert.test.js
+++ b/tests/convert.test.js
@@ -6,7 +6,9 @@ const {
   translateText,
   checkList,
   getDomain,
-  shouldTranslatePage
+  shouldTranslatePage,
+  FTPYStr,
+  JTPYStr
 } = require('../gb2312-big5/js/convert.js');
 
 describe('testChinese', () => {
@@ -61,6 +63,23 @@ describe('Pinyin', () => {
   it('keeps non-Chinese characters in place', () => {
     expect(Pinyin('A')).toBe('A');
   });
+
+  it('keeps CJK characters that are absent from the pinyin table', () => {
+    // U+3400 (㐀) is a valid CJK ideograph with no entry in the lookup table.
+    expect(Pinyin('㐀')).toBe('㐀');
+  });
+
+  it('joins pinyin for consecutive characters with a space', () => {
+    expect(Pinyin('中文')).toBe('Zhōng Wén');
+  });
+
+  it('keeps Latin text and punctuation adjacent to converted characters', () => {
+    expect(Pinyin('Hi中!')).toBe('HiZhōng !');
+  });
+
+  it('returns an empty string for an empty input', () => {
+    expect(Pinyin('')).toBe('');
+  });
 });
 
 describe('translateText', () => {
@@ -91,6 +110,34 @@ describe('translateText', () => {
 
   it('applies the Cantonese -> Mandarin dialect mapping', () => {
     expect(translateText('係', 0, 1)).toBe('是');
+  });
+
+  it('applies the Mandarin -> Cantonese dialect mapping', () => {
+    expect(translateText('他', 0, 2)).toBe('佢');
+  });
+
+  it('ignores an unknown dialect value', () => {
+    expect(translateText('係', 0, 9)).toBe('係');
+  });
+
+  it('combines dialect conversion with target encoding', () => {
+    // Cantonese -> Mandarin, then Mandarin simplified stays simplified.
+    expect(translateText('係', 1, 1)).toBe('是');
+  });
+});
+
+describe('conversion table integrity', () => {
+  it('exposes simplified and traditional tables of equal length', () => {
+    expect(JTPYStr().length).toBe(FTPYStr().length);
+  });
+
+  it('maps each simplified character to a distinct traditional counterpart', () => {
+    const simplified = JTPYStr();
+    const traditional = FTPYStr();
+    // Round-trip the first characters to guard against table drift.
+    for (let i = 0; i < 50; i += 1) {
+      expect(Traditionalized(simplified.charAt(i))).toBe(traditional.charAt(i));
+    }
   });
 });
 

--- a/tests/dom.test.js
+++ b/tests/dom.test.js
@@ -38,6 +38,30 @@ describe('translateBody', () => {
     expect(document.querySelector('img').getAttribute('alt')).toBe('簡體');
   });
 
+  it('translates the title attribute of elements', () => {
+    document.body.innerHTML = '<span title="简体">x</span>';
+    translateBody(document.body, 2, 0);
+    expect(document.querySelector('span').title).toBe('簡體');
+  });
+
+  it('translates the value of non-text input buttons', () => {
+    document.body.innerHTML = '<input type="button" value="简体">';
+    translateBody(document.body, 2, 0);
+    expect(document.querySelector('input').value).toBe('簡體');
+  });
+
+  it('leaves the value of text inputs untouched', () => {
+    document.body.innerHTML = '<input type="text" value="简体">';
+    translateBody(document.body, 2, 0);
+    expect(document.querySelector('input').value).toBe('简体');
+  });
+
+  it('falls back to document.body when no node is supplied', () => {
+    document.body.innerHTML = '<p>简体中文</p>';
+    translateBody(undefined, 2, 0);
+    expect(document.body.textContent).toBe('簡體中文');
+  });
+
   it('leaves the contents of a textarea untouched', () => {
     document.body.innerHTML = '<textarea>简体</textarea>';
     translateBody(document.body, 2, 0);

--- a/tests/i18n.test.js
+++ b/tests/i18n.test.js
@@ -5,7 +5,7 @@ const ROOT = path.resolve(__dirname, '..');
 const LOCALES_DIR = path.join(ROOT, 'gb2312-big5', '_locales');
 const MANIFEST_PATH = path.join(ROOT, 'gb2312-big5', 'manifest.json');
 
-const TOP_20_LOCALES = [
+const TOP_25_LOCALES = [
   'en',
   'zh_CN',
   'zh_TW',
@@ -25,7 +25,12 @@ const TOP_20_LOCALES = [
   'pl',
   'vi',
   'fa',
-  'th'
+  'th',
+  'bn',
+  'mr',
+  'te',
+  'ta',
+  'fil'
 ];
 
 function readLocale(locale) {
@@ -41,12 +46,12 @@ describe('extension i18n metadata', () => {
     expect(manifest.action.default_title).toBe('__MSG_appName__');
   });
 
-  it('includes top-20 language locale coverage', () => {
+  it('includes top-25 language locale coverage', () => {
     const localeDirs = fs
       .readdirSync(LOCALES_DIR)
       .filter((fileName) => fs.statSync(path.join(LOCALES_DIR, fileName)).isDirectory());
 
-    expect(localeDirs).toEqual(expect.arrayContaining(TOP_20_LOCALES));
+    expect(localeDirs).toEqual(expect.arrayContaining(TOP_25_LOCALES));
   });
 
   it('defines required messages for every locale within Chrome manifest limits', () => {


### PR DESCRIPTION
# Release 1.2 — docs, badges, i18n, tests & tooling

## Summary

This PR prepares the **1.2** release. It rounds out the repository's community
health files, expands localization to the top 25 languages, makes the README
badges dynamic, and hardens the test suite to 100% coverage of the core
conversion logic — all while keeping `npm run check` green.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature (localization + tooling)
- [ ] 💥 Breaking change
- [x] 📝 Documentation update
- [x] 🧹 Refactor / chore

## What's included

### 🔖 Version

- Bumped to **1.2** — `package.json` (`1.2.0`) and `gb2312-big5/manifest.json` (`1.2`).

### 📄 Documentation & community health

- Added `SECURITY.md` (private disclosure policy + supported versions).
- Added `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1).
- Added `CHANGELOG.md` (Keep a Changelog format, 1.0 → 1.2).
- Added `.github/PULL_REQUEST_TEMPLATE.md`.
- Added `.github/dependabot.yml` (weekly npm + GitHub Actions updates).
- README: new **Testing** and **Security** sections, refreshed project
  structure, and links to the Code of Conduct and Changelog.

### 🌍 Localization (top 25 languages)

- Added Chrome Web Store metadata for **Bengali (bn)**, **Marathi (mr)**,
  **Telugu (te)**, **Tamil (ta)**, and **Filipino (fil)** — 25 languages total.
- All locale strings verified within Chrome's manifest limits
  (`appName` ≤ 75, `appDesc` ≤ 132).

### 🏷️ README badges

- Reorganized into **Build & quality**, **Repository stats**, and
  **Chrome Web Store** groups; removed a duplicate "last commit" badge.
- Added: forks, watchers, open issues, open PRs, commit activity, repo size,
  top language, and **Ask DeepWiki**.
- Made previously **static** badges **dynamic**:
  - **JavaScript %** — self-updating via a new workflow
    (`.github/workflows/language-badge.yml`) that computes the share from
    GitHub Linguist stats and publishes a shields endpoint
    (`.github/badges/javascript.json`).
  - **Node.js** and **Manifest** — shields `dynamic/json` reading
    `engines.node` and `manifest_version` straight from the repo.

### 🧪 Tests & coverage

- Grew the Jest suite from **41 → 56 tests**; added:
  - Pinyin edge cases + conversion-table integrity checks.
  - Mandarin → Cantonese dialect mapping.
  - DOM `title`/`value`/`textarea` handling and the `document.body` fallback.
  - A new `tests/content-script.test.js` exercising the content-script bootstrap.
- **Coverage of `convert.js`: 100% statements / functions / lines** (96.77%
  branches). Raised thresholds to 95/90/95/95.

### 🛠️ Tooling & CI

- `npm run check` now also runs the **build**.
- New scripts: `fix` (lint:fix + format), `test:watch`, and `clean`
  (`scripts/clean.js`).
- CI now triggers on release branches (`[0-9]+.[0-9]+`) and a scheduled job
  keeps the language badge fresh.

### 🧹 Misc

- `main.html`, README "Support" section, and `FUNDING.yml` donation links
  refreshed (buymeacoffee / paypal).

## How has this been tested?

- `npm run check` passes locally: **lint ✓, format ✓, coverage ✓ (56 tests,
  100%), build ✓** (`dist/simplified-and-traditional-chinese-v1.2.zip`).
- Loaded the unpacked `gb2312-big5/` in Chrome and verified conversions.
- Dynamic **Node.js** and **Manifest** badges verified rendering
  (`node >=18`, `manifest v3`).

## Checklist

- [x] `npm run check` passes locally (lint + format + coverage + build).
- [x] `npm run build` produces a valid package.
- [x] New behaviour is covered by tests where practical.
- [x] Documentation (README / CONTRIBUTING) updated.
- [x] Commit messages are clear and descriptive.
- [x] I have read the CONTRIBUTING guide.

## Notes for reviewers

- The **JavaScript %** endpoint badge resolves once this branch is merged to
  `master` (the JSON it reads lives at `master/.github/badges/javascript.json`).
  The badge workflow then keeps it current — it needs permission to push to the
  default branch, so allow the Actions bot if `master` is protected.
